### PR TITLE
ci(github): add release notes workflow (git-cliff)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: "Release Notes"
+
+# Crée automatiquement une Release GitHub à chaque tag semver poussé.
+# Les notes sont générées à partir des commits conventionnels (feat:, fix:, ...)
+# entre ce tag et le tag précédent.
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+# Droit d'écriture nécessaire pour créer la Release et son tag.
+permissions:
+  contents: write
+
+jobs:
+  release-notes:
+    name: Generate release notes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history + tags)
+        uses: actions/checkout@v4
+        with:
+          # Historique complet requis pour comparer avec le tag précédent.
+          fetch-depth: 0
+
+      - name: Build changelog from conventional commits
+        id: changelog
+        uses: orhun/git-cliff-action@v4
+        with:
+          # Même config qu'en local pour un format strictement identique.
+          config: cliff.toml
+          # --latest = section du tag le plus récent (plage [tag précédent -> ce tag]).
+          args: --latest --strip all
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          # Contenu généré par git-cliff-action.
+          body: ${{ steps.changelog.outputs.content }}
+          # Marque comme pré-release si le tag contient un suffixe (-rc, -beta...).
+          prerelease: ${{ contains(github.ref_name, '-') }}

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,45 @@
+# Configuration git-cliff — utilisée à l'identique en CI (release.yml)
+# et en local (backfill). Génère des notes de release à partir des
+# commits conventionnels (feat:, fix:, ...) entre deux tags.
+# https://git-cliff.org/docs/configuration
+
+[changelog]
+# Pas d'en-tête : le titre de la Release GitHub est déjà le tag.
+header = ""
+body = """
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | striptags | trim | upper_first }}
+{% for commit in commits %}
+- {{ commit.message | upper_first | trim }}{% if commit.scope %} *({{ commit.scope }})*{% endif %} (`{{ commit.id | truncate(length=7, end="") }}`)
+{%- endfor %}
+{% endfor %}"""
+trim = true
+footer = ""
+
+[git]
+# Analyse les commits conventionnels.
+conventional_commits = true
+# Ignore les commits non conventionnels.
+filter_unconventional = true
+split_commits = false
+# Catégorisation par type. `skip` masque le type des notes.
+commit_parsers = [
+  { message = "^feat", group = "<!-- 0 -->✨ Features" },
+  { message = "^fix", group = "<!-- 1 -->🐛 Bug Fixes" },
+  { message = "^perf", group = "<!-- 2 -->🚀 Performance" },
+  { message = "^refactor", group = "<!-- 3 -->♻️ Refactors" },
+  { message = "^revert", group = "<!-- 4 -->⏪ Reverts" },
+  { message = "^docs?", skip = true },
+  { message = "^style", skip = true },
+  { message = "^test", skip = true },
+  { message = "^chore", skip = true },
+  { message = "^ci", skip = true },
+  { message = "^build", skip = true },
+  { message = ".*", skip = true },
+]
+protect_breaking_commits = false
+filter_commits = false
+# Les tags ressemblent à 2.16.0 ou v2.16.0.
+tag_pattern = "v?[0-9]+\\.[0-9]+\\.[0-9]+"
+topo_order = false
+sort_commits = "newest"


### PR DESCRIPTION
## Résumé

Ajoute la génération automatique de notes de Release GitHub à chaque tag semver poussé, via **git-cliff** (même dispositif que le repo `platform`).

- ➕ `cliff.toml` : config partagée (commits conventionnels regroupés feat/fix/perf/refactor/revert ; ci/chore/docs/style/build/test exclus).
- ➕ `.github/workflows/release.yml` : `orhun/git-cliff-action@v4` + `softprops/action-gh-release@v2`, déclenché sur tag.

Les Releases historiques sont par ailleurs reconstruites au même format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)