### PR TITLE
ci(core): group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,16 @@ updates:
     labels:
       - "dependencies"
       - "python"
+    # One grouped PR carries a single coherent uv.lock resolution. Merging
+    # ungrouped lockfile PRs in sequence replays stale diffs onto a moved
+    # base, which git merges without conflict but leaves inconsistent.
+    groups:
+      python-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
@@ -21,3 +31,7 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Mirrors the config `qalita/platform` already uses, applied to `pip` and `github-actions`.

Grouping is not only about volume. Merging several ungrouped lockfile PRs in sequence replays stale diffs onto a moved base — git merges them without conflict, but the result is inconsistent. That is how a corrupt lockfile reached `main` on `qalita/website`. One grouped PR carries a single coherent `uv.lock` resolution instead.

It matters more here than elsewhere: CI on this repo runs **only CodeQL, reporting NEUTRAL** — no tests, no build. A bad dependency bump has nothing standing in its way, so reducing the number of independent merges is the main lever available.