### PR TITLE
fix: empêcher le loader de modifier silencieusement les données

### DIFF
--- a/qalita_core/data_source_opener.py
+++ b/qalita_core/data_source_opener.py
@@ -441,11 +441,37 @@ def _stage_remote_file(path: str, storage_options: Optional[dict]) -> str:
 
     local_dir = Path(os.environ.get("TMPDIR", "/tmp")) / "qalita-staging"
     local_dir.mkdir(parents=True, exist_ok=True)
-    local_path = local_dir / os.path.basename(path.rstrip("/"))
 
-    with fsspec.open(path, "rb", **(storage_options or {})) as remote:
-        with open(local_path, "wb") as local:
-            shutil.copyfileobj(remote, local, length=8 * 1024 * 1024)
+    # The basename alone collides: s3://a/data.csv and s3://b/data.csv stage to
+    # the same file, and the second source silently analyses the first one's
+    # bytes. The digest of the full path disambiguates without making the name
+    # unreadable. blake2s, not sha1: a weak-hash warning on every staged file
+    # trains people to ignore the scanner.
+    base = os.path.basename(path.rstrip("/")) or "object"
+    digest = hashlib.blake2s(path.encode("utf-8"), digest_size=4).hexdigest()
+    local_path = local_dir / f"{digest}-{base}"
+
+    opened = fsspec.open(path, "rb", **(storage_options or {}))
+    with opened as remote:
+        # Ask the remote how big it is before writing a byte. Without this a
+        # 100 GiB object fills the staging volume and the failure surfaces as
+        # ENOSPC halfway through, leaving a truncated file behind that looks
+        # like a complete one.
+        size = None
+        try:
+            size = opened.fs.size(path)
+        except Exception:  # noqa: BLE001 - not every filesystem reports size
+            logger.debug("could not determine remote size of %s", path)
+        pio.check_disk_space(str(local_dir), size)
+
+        try:
+            with open(local_path, "wb") as local:
+                shutil.copyfileobj(remote, local, length=8 * 1024 * 1024)
+        except BaseException:
+            # A partial copy is worse than none: it is a valid-looking file the
+            # next run would happily scan.
+            local_path.unlink(missing_ok=True)
+            raise
     return str(local_path)
 
 
@@ -1084,6 +1110,19 @@ class S3Source(DataSource):
     def __init__(self, config):
         self.config = config or {}
 
+    def _object_key_is_the_path(self) -> bool:
+        """Whether ``config['key']`` names the object rather than the account.
+
+        ``key`` means two different things in the configs this class accepts:
+        fsspec spells the access key ``key``, and :meth:`get_data` builds
+        ``s3://{bucket}/{key}`` when no explicit ``path`` is given. Reading it
+        as a credential in that second case sent the object's own name to S3 as
+        ``aws_access_key_id`` — an authentication failure on every private
+        bucket configured with bucket+key, reported as a credentials problem
+        the user could not find because the credentials were correct.
+        """
+        return not self.config.get("path") and bool(self.config.get("bucket"))
+
     def _storage_options(self) -> Optional[dict]:
         """Credentials in the naming Polars' object store expects.
 
@@ -1093,10 +1132,11 @@ class S3Source(DataSource):
         """
         config = self.config
         client_kwargs = config.get("client_kwargs") or {}
+        access_key_aliases = ["access_key", "aws_access_key_id"]
+        if not self._object_key_is_the_path():
+            access_key_aliases.insert(0, "key")
         options = {
-            "aws_access_key_id": _first_of(
-                config, "key", "access_key", "aws_access_key_id"
-            ),
+            "aws_access_key_id": _first_of(config, *access_key_aliases),
             "aws_secret_access_key": _first_of(
                 config, "secret", "secret_key", "aws_secret_access_key"
             ),

--- a/qalita_core/polars_io.py
+++ b/qalita_core/polars_io.py
@@ -242,20 +242,69 @@ def _castable(column: Any, target: "pa.DataType") -> bool:
     return True
 
 
+_INTEGER_DIGITS = {8: 3, 16: 5, 32: 10, 64: 19}
+
+
+def _decimal_parts(dtype: "pa.DataType") -> Optional[tuple]:
+    """``(integer digits, scale)`` needed to hold every value of ``dtype``."""
+    if pa.types.is_decimal(dtype):
+        return dtype.precision - dtype.scale, dtype.scale
+    if pa.types.is_integer(dtype):
+        digits = _INTEGER_DIGITS.get(dtype.bit_width)
+        if digits is None:
+            return None
+        if not pa.types.is_signed_integer(dtype):
+            digits += 1
+        return digits, 0
+    return None
+
+
+def _covering_decimal(
+    pinned: "pa.DataType", incoming: "pa.DataType"
+) -> Optional["pa.DataType"]:
+    """The narrowest decimal holding both, or None when no standard one does.
+
+    Absorbing a longer scale by widening to float64 would reintroduce exactly
+    the silent rounding that keeping Decimal out of float exists to prevent, so
+    a decimal column widens to a wider decimal or not at all.
+    """
+    left = _decimal_parts(pinned)
+    right = _decimal_parts(incoming)
+    if left is None or right is None:
+        return None
+    scale = max(left[1], right[1])
+    precision = max(left[0], right[0]) + scale
+    if precision <= 38:
+        return pa.decimal128(precision, scale)
+    if precision <= 76:
+        return pa.decimal256(precision, scale)
+    return None
+
+
 def _wider_types(
     pinned: "pa.DataType", incoming: "pa.DataType"
 ) -> List["pa.DataType"]:
     """Types that could hold both the pinned column and the new batch.
 
-    The ladder is monotone and short — integer -> float64 -> text — so a
-    pathological source can trigger at most two rewrites of a column, and never
-    a rewrite back towards a narrower type. ``large_string`` is terminal: once a
-    column is text there is nothing wider to promote it to.
+    The ladder is monotone — nothing ever promotes back towards a narrower
+    type — and ``large_string`` is terminal: once a column is text there is
+    nothing wider to promote it to. Numbers reach text through at most one
+    intermediate step (integer -> float64 -> text).
+
+    Decimals are the one place a column can widen more than twice: a source
+    whose batches carry a growing scale walks decimal128(p,s) upwards one step
+    per surprise. It is bounded by precision 38 (then 76 via decimal256), and
+    each step is a rewrite of the parts already on disk — the alternative,
+    collapsing to float64 on the first scale change, silently rounds the
+    values instead.
     """
     candidates: List["pa.DataType"] = []
-    if pa.types.is_integer(pinned) and (
-        pa.types.is_floating(incoming) or pa.types.is_decimal(incoming)
-    ):
+    covering = _covering_decimal(pinned, incoming)
+    if covering is not None:
+        candidates.append(covering)
+    if (
+        pa.types.is_integer(pinned) or pa.types.is_decimal(pinned)
+    ) and pa.types.is_floating(incoming):
         candidates.append(pa.float64())
     candidates.append(pa.large_string())
     return [c for c in candidates if not c.equals(pinned)]
@@ -702,9 +751,13 @@ def _arrow_safe(value: Any) -> Any:
     """
     if isinstance(value, (dict, list, tuple, set)):
         return json.dumps(value, default=str)
-    if isinstance(value, Decimal):
-        return float(value)
-    if isinstance(value, (str, bytes, bool, int, float, type(None))):
+    if isinstance(value, (str, bytes, bool, int, float, Decimal, type(None))):
+        # Decimal is handed to Arrow as-is, which types it decimal128/256 and
+        # keeps every digit. It used to be float()ed here, which silently
+        # rounded any value past float64's ~15 significant digits: a
+        # NUMERIC(38,2) ledger amount came out of the loader different from
+        # the value in the database, and every metric computed on it was
+        # computed on the wrong number.
         return value
     if isinstance(value, (_dt.datetime, _dt.date, _dt.time)):
         return value
@@ -991,8 +1044,15 @@ def sniff_json_format(file_path: str) -> str:
     The loader used to take this from a ``json_lines`` config flag that defaults
     to False, so an NDJSON file was read with ``pl.read_json`` — the whole
     document at once — unless the caller happened to know to set it.
+
+    ``utf-8-sig`` because a UTF-8 BOM is not whitespace: with plain ``utf-8``
+    the first character of a BOM-prefixed array is ``\\ufeff``, not ``[``, and
+    every file written by a Windows exporter was classified as NDJSON and then
+    failed to parse.
     """
-    with open(file_path, "r", encoding="utf-8", errors="replace") as handle:
+    with open(
+        file_path, "r", encoding="utf-8-sig", errors="replace"
+    ) as handle:
         while True:
             character = handle.read(1)
             if not character:
@@ -1013,7 +1073,7 @@ def iter_json_array(
     table: a top-level array.
     """
     decoder = json.JSONDecoder()
-    with open(file_path, "r", encoding="utf-8") as handle:
+    with open(file_path, "r", encoding="utf-8-sig") as handle:
         buffer = handle.read(buffer_size)
         index = _skip_space(buffer, 0)
         if index >= len(buffer) or buffer[index] != "[":
@@ -1041,15 +1101,39 @@ def iter_json_array(
             if buffer[index] == "]":
                 return
 
+            start = index
             while True:
                 try:
-                    value, index = decoder.raw_decode(buffer, index)
-                    break
+                    value, end = decoder.raw_decode(buffer, start)
                 except ValueError:
                     more = handle.read(buffer_size)
                     if not more:
                         raise
                     buffer += more
+                    continue
+
+                # A successful decode is not proof the value was complete.
+                # raw_decode stops at the first character that cannot continue
+                # the token, so a buffer holding " 9." yields 9 and leaves
+                # ".75" to be read as a second element, and one ending in
+                # "123" yields 123 before "456" arrives. In an array every
+                # element is followed by ',' or ']', so that is the only thing
+                # that proves the buffer held all of it.
+                after = _skip_space(buffer, end)
+                if after < len(buffer) and buffer[after] in ",]":
+                    break
+                more = handle.read(buffer_size)
+                if not more:
+                    if after >= len(buffer):
+                        # End of file right after the value: the document is
+                        # missing its ']', but the element itself is whole.
+                        break
+                    raise ValueError(
+                        f"{file_path}: {buffer[after]!r} follows a value "
+                        f"where ',' or ']' was expected."
+                    )
+                buffer += more
+            index = end
             yield value
 
 

--- a/tests/test_ingestion_fidelity.py
+++ b/tests/test_ingestion_fidelity.py
@@ -1,0 +1,407 @@
+"""Regressions for the ways the loader could quietly change the data.
+
+Each test here corresponds to a defect that produced *plausible* output: a
+number close to the right one, a file that parsed, an element that decoded.
+Nothing raised, so nothing caught them except reading the values back.
+"""
+
+import json
+from decimal import Decimal
+
+import pyarrow as pa
+import pytest
+
+from qalita_core import polars_io as pio
+from qalita_core.data_source_opener import (
+    S3Source,
+    _SqlAlchemySource,
+    _stage_remote_file,
+)
+
+# ---------------------------------------------------------------------------
+# Decimal fidelity
+# ---------------------------------------------------------------------------
+
+
+def test_decimal_reaches_arrow_untouched():
+    """float() used to be applied here, rounding away everything past ~15
+    significant digits."""
+    value = Decimal("12345678901234567890.12")
+    assert pio._arrow_safe(value) is value
+
+
+def test_decimal_column_keeps_every_digit_through_the_writer(tmp_path):
+    exact = Decimal("12345678901234567890.12")
+    with pio.ParquetPartWriter(str(tmp_path), "ledger") as writer:
+        writer.write(pa.table({"amount": pa.array([exact, Decimal("0.01")])}))
+    paths = writer.close()
+
+    import polars as pl
+
+    frame = pl.scan_parquet(paths).collect(engine="streaming")
+    assert frame["amount"].to_list()[0] == exact
+
+
+def test_float_would_have_lost_that_value():
+    """The guard behind the test above: this is what the old code emitted."""
+    exact = Decimal("12345678901234567890.12")
+    assert Decimal(str(float(exact))) != exact
+
+
+def test_a_decimal_column_still_profiles_as_a_number(tmp_path):
+    """Keeping Decimal is only worth anything if the packs can still use the
+    column: a NUMERIC that profiles as text would be a worse regression than
+    the rounding it replaces."""
+    from qalita_core import analytics, profiling
+
+    with pio.ParquetPartWriter(str(tmp_path), "ledger") as writer:
+        writer.write(
+            pa.table(
+                {
+                    "amount": pa.array(
+                        [Decimal("1.25"), Decimal("2.50"), Decimal("100.00")]
+                    )
+                }
+            )
+        )
+    paths = writer.close()
+
+    import polars as pl
+
+    lazy = pl.scan_parquet(paths)
+    assert analytics.numeric_columns(dict(lazy.collect_schema())) == ["amount"]
+
+    report = profiling.profile(lazy)["amount"]
+    # the sum is carried exactly, not as 103.75000000000001
+    assert Decimal(str(report["sum"])) == Decimal("103.75")
+    assert report["n_missing"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Schema widening
+# ---------------------------------------------------------------------------
+
+
+def test_wider_decimal_covers_both_scales():
+    covering = pio._covering_decimal(pa.decimal128(5, 2), pa.decimal128(7, 4))
+    # 3 integer digits on the left, 3 on the right, scale 4 -> 7 digits
+    assert covering == pa.decimal128(7, 4)
+
+
+def test_decimal_widens_to_decimal_not_to_text():
+    """Collapsing to large_string on a scale change would keep the digits but
+    lose the type; collapsing to float64 would keep the type and lose the
+    digits. Neither is acceptable for a numeric column."""
+    wider = pio._wider_types(pa.decimal128(5, 2), pa.decimal128(7, 4))
+    assert wider[0] == pa.decimal128(7, 4)
+
+
+def test_decimal_beyond_decimal128_goes_to_decimal256():
+    covering = pio._covering_decimal(
+        pa.decimal128(38, 0), pa.decimal128(38, 20)
+    )
+    assert pa.types.is_decimal256(covering)
+    assert covering.scale == 20
+
+
+def test_integer_and_decimal_meet_on_a_decimal():
+    covering = pio._covering_decimal(pa.int64(), pa.decimal128(10, 4))
+    assert pa.types.is_decimal(covering)
+    assert covering.scale == 4
+    # int64 needs 19 integer digits, so the result must hold 19 + 4
+    assert covering.precision == 23
+
+
+def test_unsigned_integer_gets_its_extra_digit():
+    covering = pio._covering_decimal(pa.uint64(), pa.decimal128(5, 2))
+    assert covering.precision == 20 + 2
+
+
+def test_text_stays_terminal():
+    assert pio._wider_types(pa.large_string(), pa.int64()) == []
+
+
+def test_growing_scale_across_batches_keeps_the_values(tmp_path):
+    with pio.ParquetPartWriter(str(tmp_path), "ledger") as writer:
+        writer.write(pa.table({"amount": pa.array([Decimal("1.25")])}))
+        writer.write(pa.table({"amount": pa.array([Decimal("1.2345")])}))
+    paths = writer.close()
+
+    import polars as pl
+
+    values = pl.scan_parquet(paths).collect(engine="streaming")["amount"]
+    assert [str(v) for v in values.to_list()] == ["1.2500", "1.2345"]
+
+
+# ---------------------------------------------------------------------------
+# JSON streaming
+# ---------------------------------------------------------------------------
+
+
+def test_scalar_split_across_the_buffer_is_one_value(tmp_path):
+    """raw_decode returns 123 for a buffer ending in "123" whose file
+    continues "456": the element used to be yielded twice, wrong both times."""
+    path = tmp_path / "numbers.json"
+    path.write_text("[123456789, 2]", encoding="utf-8")
+    # a buffer that ends in the middle of the first number
+    values = list(pio.iter_json_array(str(path), buffer_size=6))
+    assert values == [123456789, 2]
+
+
+@pytest.mark.parametrize("buffer_size", list(range(2, 20)))
+def test_every_buffer_boundary_yields_the_same_elements(tmp_path, buffer_size):
+    path = tmp_path / "mixed.json"
+    payload = [1234, "abcdef", {"k": 5678}, [1, 2], True, None, 9.75]
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    assert list(pio.iter_json_array(str(path), buffer_size=buffer_size)) == (
+        payload
+    )
+
+
+def test_json_array_behind_a_utf8_bom_is_read(tmp_path):
+    path = tmp_path / "bom.json"
+    path.write_text("﻿[1, 2, 3]", encoding="utf-8")
+    assert list(pio.iter_json_array(str(path))) == [1, 2, 3]
+
+
+def test_bom_prefixed_array_is_sniffed_as_an_array(tmp_path):
+    """A BOM is not whitespace: with plain utf-8 the first character is
+    \\ufeff, not '[', and every Windows-exported file was called NDJSON."""
+    path = tmp_path / "bom.json"
+    path.write_text("﻿[1, 2]", encoding="utf-8")
+    assert pio.sniff_json_format(str(path)) == "array"
+
+
+def test_ndjson_is_still_ndjson(tmp_path):
+    path = tmp_path / "lines.json"
+    path.write_text('{"a": 1}\n{"a": 2}\n', encoding="utf-8")
+    assert pio.sniff_json_format(str(path)) == "ndjson"
+
+
+def test_truncated_array_still_raises(tmp_path):
+    path = tmp_path / "broken.json"
+    path.write_text('[{"a": 1}, {"a":', encoding="utf-8")
+    with pytest.raises(ValueError):
+        list(pio.iter_json_array(str(path)))
+
+
+# ---------------------------------------------------------------------------
+# S3 credentials
+# ---------------------------------------------------------------------------
+
+
+def test_object_key_is_not_sent_as_the_access_key():
+    """bucket+key builds s3://bucket/key, so `key` names the object. Reading
+    it as a credential authenticated with the object's own name."""
+    source = S3Source(
+        {
+            "bucket": "reports",
+            "key": "2026/august/ledger.parquet",
+            "access_key": "AKIAREAL",
+            "secret": "s3cret",
+        }
+    )
+    options = source._storage_options()
+    assert options["aws_access_key_id"] == "AKIAREAL"
+
+
+def test_fsspec_style_key_is_still_a_credential_when_path_is_explicit():
+    source = S3Source(
+        {
+            "path": "s3://reports/ledger.parquet",
+            "key": "AKIAREAL",
+            "secret": "s3cret",
+        }
+    )
+    assert source._storage_options()["aws_access_key_id"] == "AKIAREAL"
+
+
+def test_bucket_and_key_without_credentials_sends_none():
+    source = S3Source({"bucket": "public", "key": "open/data.parquet"})
+    assert source._storage_options() is None
+
+
+# ---------------------------------------------------------------------------
+# Remote staging
+# ---------------------------------------------------------------------------
+
+
+class _FakeFs:
+    def __init__(self, size):
+        self._size = size
+
+    def size(self, _path):
+        return self._size
+
+
+class _FakeOpen:
+    def __init__(self, payload, size):
+        self.payload = payload
+        self.fs = _FakeFs(size)
+
+    def __enter__(self):
+        import io
+
+        return io.BytesIO(self.payload)
+
+    def __exit__(self, *exc):
+        return False
+
+
+@pytest.fixture
+def fake_fsspec(monkeypatch, tmp_path):
+    import sys
+    import types
+
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+    module = types.ModuleType("fsspec")
+    module.open = lambda path, mode, **kw: module._handle
+    monkeypatch.setitem(sys.modules, "fsspec", module)
+    return module
+
+
+def test_same_basename_from_two_buckets_stages_to_two_files(
+    fake_fsspec, tmp_path
+):
+    """Both used to land on <TMPDIR>/qalita-staging/data.csv, so the second
+    source analysed the first one's bytes."""
+    fake_fsspec._handle = _FakeOpen(b"a,b\n1,2\n", 8)
+    first = _stage_remote_file("s3://one/data.csv", None)
+    fake_fsspec._handle = _FakeOpen(b"c,d\n3,4\n", 8)
+    second = _stage_remote_file("s3://two/data.csv", None)
+
+    assert first != second
+    assert open(first, "rb").read() == b"a,b\n1,2\n"
+    assert open(second, "rb").read() == b"c,d\n3,4\n"
+
+
+def test_staging_refuses_an_object_that_will_not_fit(fake_fsspec):
+    fake_fsspec._handle = _FakeOpen(b"x", 1 << 60)
+    with pytest.raises(pio.InsufficientDiskSpaceError):
+        _stage_remote_file("s3://one/huge.csv", None)
+
+
+def test_an_unknown_remote_size_does_not_block_the_copy(fake_fsspec):
+    class _NoSize(_FakeOpen):
+        def __init__(self, payload):
+            super().__init__(payload, 0)
+            self.fs = None
+
+    fake_fsspec._handle = _NoSize(b"ok")
+    # fs is None -> .size() raises AttributeError -> treated as "unknown"
+    assert open(_stage_remote_file("s3://one/x.csv", None), "rb").read() == (
+        b"ok"
+    )
+
+
+def test_a_failed_copy_leaves_no_truncated_file(fake_fsspec, tmp_path):
+    class _Exploding(_FakeOpen):
+        def __enter__(self):
+            class _Reader:
+                def read(self, *_a):
+                    raise OSError("connection reset")
+
+            return _Reader()
+
+    fake_fsspec._handle = _Exploding(b"", 8)
+    with pytest.raises(OSError):
+        _stage_remote_file("s3://one/data.csv", None)
+
+    staged = tmp_path / "qalita-staging"
+    assert list(staged.glob("*")) == []
+
+
+# ---------------------------------------------------------------------------
+# The shared SQL dispatch
+# ---------------------------------------------------------------------------
+
+
+class _RecordingSource(_SqlAlchemySource):
+    """Every warehouse class now shares one _load_data. These tests drive that
+    single implementation, which is what all sixteen subclasses inherit."""
+
+    dialect_name = "warehouse"
+
+    def __init__(self):
+        self.tables_read = []
+
+    def get_data(self, table_or_query=None, pack_config=None):
+        raise NotImplementedError
+
+    def _list_tables(self, engine, schema):
+        return ["alpha", "beta"]
+
+    def _read_table_to_parquet(
+        self, engine, table_name, schema, output_dir, chunk_rows, dialect, **kw
+    ):
+        self.tables_read.append(table_name)
+        return [f"/out/{table_name}.parquet"]
+
+    def _object_base_name(self, dialect_name, suffix):
+        return f"{dialect_name}_{suffix}"
+
+
+def _load(source, table_or_query):
+    return source._load_data(
+        engine=object(),
+        table_or_query=table_or_query,
+        schema=None,
+        output_dir="/out",
+        chunk_rows=1000,
+    )
+
+
+def test_none_loads_every_table():
+    source = _RecordingSource()
+    assert _load(source, None) == [
+        "/out/alpha.parquet",
+        "/out/beta.parquet",
+    ]
+
+
+def test_star_loads_every_table():
+    source = _RecordingSource()
+    _load(source, "*")
+    assert source.tables_read == ["alpha", "beta"]
+
+
+def test_a_list_loads_exactly_those_tables():
+    source = _RecordingSource()
+    _load(source, ["gamma", "delta"])
+    assert source.tables_read == ["gamma", "delta"]
+
+
+def test_a_bare_name_is_a_table_not_a_query():
+    source = _RecordingSource()
+    _load(source, "customers")
+    assert source.tables_read == ["customers"]
+
+
+def test_a_select_goes_down_the_query_path(monkeypatch):
+    seen = {}
+
+    def fake_sql_to_parquet(
+        _self, _engine, query, output_dir, base, chunk_rows, **kw
+    ):
+        seen["query"] = query
+        seen["base"] = base
+        return ["/out/query.parquet"]
+
+    monkeypatch.setattr(
+        "qalita_core.data_source_opener._sql_to_parquet", fake_sql_to_parquet
+    )
+    source = _RecordingSource()
+    assert _load(source, "SELECT 1") == ["/out/query.parquet"]
+    assert source.tables_read == []
+    assert seen["base"] == "warehouse_query"
+
+
+def test_an_unusable_argument_is_refused():
+    with pytest.raises(TypeError):
+        _load(_RecordingSource(), 42)
+
+
+def test_qualify_uses_the_schema_when_there_is_one():
+    source = _RecordingSource()
+    assert source._qualify("t", "public") == ("public.t", "public.t")
+    assert source._qualify("t", None) == ("t", "t")


### PR DESCRIPTION
Cinq défauts qui produisaient tous une sortie **plausible** — un nombre proche du bon, un fichier qui parse, un élément qui décode. Rien ne levait, et rien à part relire les valeurs ne les attrapait.

## Decimal → float

Un `Decimal` était `float()`é en entrant dans Arrow, ce qui arrondissait tout ce qui dépasse ~15 chiffres significatifs. Un montant `NUMERIC(38,2)` sortait du loader **différent de la valeur en base**, et toutes les métriques calculées dessus l'étaient sur le mauvais nombre.

Il atteint maintenant Arrow en `decimal128`/`decimal256`. Vérifié : Polars 1.37 les type en `pl.Decimal`, les compte comme numériques et les somme **exactement** — un test le garde, parce qu'une colonne NUMERIC qui profilerait en texte serait une régression pire que l'arrondi qu'elle remplace.

`_wider_types` gagne l'élargissement décimal qui va avec. Sans lui, un batch de scale plus longue promouvait la colonne en texte (chiffres gardés, type perdu) ou en float64 (type gardé, chiffres perdus).

## `iter_json_array` rendait des valeurs tronquées

`raw_decode` s'arrête au premier caractère qui ne peut pas continuer le token : un buffer contenant `" 9."` renvoie `9` et laisse `".75"` être lu comme un **deuxième élément**.

Ce qui l'a trouvé : balayer toutes les tailles de buffer de 2 à 19 sur une charge mixte. **Ma première correction ne suffisait pas** — exiger que la valeur se termine avant la fin du buffer laisse passer exactement ce cas. Un élément n'est désormais accepté que si une `,` ou un `]` le suit.

## BOM

Les fichiers JSON sont lus en `utf-8-sig`. Un BOM n'est pas un espace : tout tableau exporté depuis Windows était sniffé comme NDJSON, puis échouait au parsing.

## S3Source : la clé de l'objet envoyée comme identifiant

`fsspec` orthographie la clé d'accès `key`, et `get_data` construit `s3://{bucket}/{key}`. Une config `bucket`+`key` envoyait donc **le nom de l'objet** à S3 comme `aws_access_key_id`. Ça se manifestait par un échec d'authentification impossible à diagnostiquer, puisque les identifiants étaient corrects.

## `_stage_remote_file`

Interroge maintenant la taille distante et refuse de commencer si ça ne rentre pas, au lieu de remplir le volume et d'échouer à mi-parcours en laissant un fichier tronqué qui a l'air complet. Les noms stagés portent un digest du chemin distant complet : `s3://a/data.csv` et `s3://b/data.csv` atterrissaient sur le même fichier local, donc la seconde source analysait les octets de la première.

## Tests

**48 nouveaux**, dont la couverture du dispatch partagé `_SqlAlchemySource` sur lequel seize classes d'entrepôts ont été fusionnées et que rien n'exerçait. Suite core : **601 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)