### PR TITLE
fix(csv): honour the delimiter, encoding, header and decimal separator declared on the source

### DIFF
--- a/qalita_core/data_source_opener.py
+++ b/qalita_core/data_source_opener.py
@@ -623,7 +623,7 @@ def _csv_read_options(config: Optional[dict]) -> Dict[str, Any]:
 
     has_header = config.get("has_header")
     if has_header is not None:
-        options["has_header"] = bool(has_header)
+        options["has_header"] = _config_flag(has_header, default=True)
 
     decimal_separator = config.get("decimal_separator")
     if decimal_separator not in (None, ""):
@@ -634,9 +634,20 @@ def _csv_read_options(config: Optional[dict]) -> Dict[str, Any]:
             )
         options["decimal_comma"] = decimal_separator == ","
     elif config.get("decimal_comma") is not None:
-        options["decimal_comma"] = bool(config["decimal_comma"])
+        options["decimal_comma"] = _config_flag(
+            config["decimal_comma"], default=False
+        )
 
     return options
+
+
+def _config_flag(value: Any, default: bool) -> bool:
+    """Parse a platform flag using the CLI's legacy-compatible semantics."""
+    if value is None:
+        return default
+    if isinstance(value, str):
+        return value.strip().lower() not in ("", "false", "0", "no")
+    return bool(value)
 
 
 class FileSource(DataSource):

--- a/qalita_core/data_source_opener.py
+++ b/qalita_core/data_source_opener.py
@@ -584,9 +584,67 @@ def _as_documents(values: Iterable[Any]) -> Iterator[Dict[str, Any]]:
             yield {"value": value}
 
 
+def _csv_read_options(config: Optional[dict]) -> Dict[str, Any]:
+    """Translate a file source config into ``pio.scan_csv`` keyword options.
+
+    The keys are the ones the platform stores on a CSV source and the CLI
+    worker reads for its own preview (qalita/cli#143): the two readers have to
+    agree, or the pack profiles a file the user never saw in the Studio.
+
+    Every unusable value raises instead of falling back to the default. A
+    silent fallback is what makes this class of bug expensive: reading a ``;``
+    file as comma-separated does not fail, it yields one column and a green job
+    whose metrics describe nothing.
+    """
+    config = config or {}
+    options: Dict[str, Any] = {}
+
+    delimiter = config.get("delimiter")
+    if delimiter not in (None, ""):
+        # The form field is free text, so a tabulation is typed as the two
+        # characters ``\t`` far more often than as a real tabulation.
+        separator = "\t" if delimiter == "\\t" else str(delimiter)
+        if len(separator) != 1:
+            raise ValueError(
+                f"Invalid CSV delimiter {delimiter!r}: a separator must be "
+                "exactly one character (write a tabulation as '\\t')."
+            )
+        options["separator"] = separator
+
+    encoding = config.get("encoding")
+    if encoding not in (None, ""):
+        if str(encoding).lower().replace("_", "-") not in pio.UTF8_ENCODINGS:
+            raise ValueError(
+                f"Unsupported CSV encoding {encoding!r}: the loader only reads "
+                "the utf-8 family. Convert the file to UTF-8 and declare "
+                "'utf-8' on the source."
+            )
+        options["encoding"] = "utf8"
+
+    has_header = config.get("has_header")
+    if has_header is not None:
+        options["has_header"] = bool(has_header)
+
+    decimal_separator = config.get("decimal_separator")
+    if decimal_separator not in (None, ""):
+        if decimal_separator not in (".", ","):
+            raise ValueError(
+                f"Invalid CSV decimal separator {decimal_separator!r}: "
+                "expected '.' or ','."
+            )
+        options["decimal_comma"] = decimal_separator == ","
+    elif config.get("decimal_comma") is not None:
+        options["decimal_comma"] = bool(config["decimal_comma"])
+
+    return options
+
+
 class FileSource(DataSource):
-    def __init__(self, file_path):
+    def __init__(self, file_path, config=None):
         self.file_path = file_path
+        # Optional so that the dozens of ``FileSource(path)`` call sites keep
+        # working; only the CSV reader looks at it.
+        self.config = config or {}
 
     def get_data(self, table_or_query=None, pack_config=None):
         output_dir = _ensure_output_dir(pack_config)
@@ -638,7 +696,11 @@ class FileSource(DataSource):
         if lower.endswith(".csv"):
             return _sink_to_parquet(
                 self,
-                pio.scan_csv(file_path, skip_rows=int(skiprows)),
+                pio.scan_csv(
+                    file_path,
+                    skip_rows=int(skiprows),
+                    **_csv_read_options(self.config),
+                ),
                 output_dir,
                 base_name,
                 chunk_rows,
@@ -1042,16 +1104,22 @@ def _materialize_remote_to_parquet(
         )
 
     if fmt == "csv":
+        # Object stores hold the same European CSVs as local disks do, and the
+        # source config carries the same keys, so the reader options apply here
+        # too.
+        csv_options = _csv_read_options(getattr(source, "config", None))
         if native:
             lf = pio.scan_csv(
                 path,
                 skip_rows=int(skiprows),
                 storage_options=storage_options,
+                **csv_options,
             )
         else:
             lf = pio.scan_csv(
                 _stage_remote_file(path, storage_options),
                 skip_rows=int(skiprows),
+                **csv_options,
             )
         return _sink_to_parquet(
             source,
@@ -2566,7 +2634,7 @@ def get_data_source(source_config):
 
     # File sources
     if type_ in ("file", "csv", "excel", "json", "parquet"):
-        return FileSource(config.get("path"))
+        return FileSource(config.get("path"), config=config)
     elif type_ == "folder":
         return FolderSource(config)
 

--- a/qalita_core/polars_io.py
+++ b/qalita_core/polars_io.py
@@ -52,6 +52,7 @@ __all__ = [
     "InsufficientDiskSpaceError",
     "ParquetPartWriter",
     "SchemaDriftError",
+    "UTF8_ENCODINGS",
     "arrow_type_hints",
     "check_disk_space",
     "iter_excel_rows",
@@ -88,6 +89,12 @@ DEFAULT_MIN_FREE_BYTES = 512 * 1024 * 1024
 # of file. The pandas path used to write snappy silently while the Polars path
 # wrote zstd, which made part files of the same object differ in size by 3x.
 PARQUET_COMPRESSION = "zstd"
+
+# Encoding names that Polars reads natively under the single name ``utf8``.
+# Anything else has to be transcoded before it reaches the reader, so the
+# loader refuses it rather than handing Polars a name it will reject with
+# "invalid utf-8 sequence" halfway through the file.
+UTF8_ENCODINGS = ("utf-8", "utf8", "utf-8-sig", "utf8-sig", "ascii")
 
 
 class InsufficientDiskSpaceError(RuntimeError):
@@ -918,17 +925,29 @@ def scan_csv(
     *,
     skip_rows: int = 0,
     encoding: str = "utf8",
+    separator: str = ",",
+    has_header: bool = True,
+    decimal_comma: bool = False,
     infer_schema_length: int = 10000,
     ignore_errors: bool = True,
     **kwargs: Any,
 ) -> "pl.LazyFrame":
-    """Lazily scan a CSV. Nothing is read until the plan is executed."""
-    if encoding.lower() in ("utf-8", "utf_8"):
+    """Lazily scan a CSV. Nothing is read until the plan is executed.
+
+    ``truncate_ragged_lines`` is deliberately left off: a file read with the
+    wrong separator must fail here rather than come back as one wide string
+    column that every downstream metric would then describe.
+    """
+    if encoding.lower().replace("_", "-") in UTF8_ENCODINGS:
+        # Polars names the whole family ``utf8`` and strips a BOM on its own.
         encoding = "utf8"
     return pl.scan_csv(
         file_path,
         skip_rows=skip_rows,
         encoding=encoding,
+        separator=separator,
+        has_header=has_header,
+        decimal_comma=decimal_comma,
         infer_schema_length=infer_schema_length,
         ignore_errors=ignore_errors,
         **kwargs,

--- a/tests/test_data_source_opener.py
+++ b/tests/test_data_source_opener.py
@@ -876,6 +876,60 @@ class TestCsvSourceOptions:
         assert frame.columns == ["column_1", "column_2"]
         assert frame["column_1"].to_list() == [1, 2]
 
+    def test_has_header_string_false_keeps_the_first_line_as_data(
+        self, tmp_path
+    ):
+        csv_path = tmp_path / "headless-string.csv"
+        csv_path.write_text("1;alpha\n2;beta\n", encoding="utf-8")
+        source = FileSource(
+            str(csv_path),
+            config={
+                "path": str(csv_path),
+                "delimiter": ";",
+                "has_header": "false",
+            },
+        )
+
+        frame = self._collect(source, tmp_path)
+
+        assert frame.height == 2
+        assert frame.columns == ["column_1", "column_2"]
+        assert frame["column_1"].to_list() == [1, 2]
+
+    def test_decimal_comma_string_false_keeps_decimal_values_as_strings(
+        self, tmp_path
+    ):
+        csv_path = self._european(tmp_path)
+        source = FileSource(
+            str(csv_path),
+            config={
+                "path": str(csv_path),
+                "delimiter": ";",
+                "decimal_comma": "false",
+            },
+        )
+
+        frame = self._collect(source, tmp_path)
+
+        assert frame.schema["hba1c_pct"] == pl.String
+        assert frame["hba1c_pct"].to_list() == ["8,4", "6,1", "7,25"]
+
+    def test_decimal_comma_string_true_infers_decimal_values(self, tmp_path):
+        csv_path = self._european(tmp_path)
+        source = FileSource(
+            str(csv_path),
+            config={
+                "path": str(csv_path),
+                "delimiter": ";",
+                "decimal_comma": "true",
+            },
+        )
+
+        frame = self._collect(source, tmp_path)
+
+        assert frame.schema["hba1c_pct"] == pl.Float64
+        assert frame["hba1c_pct"].to_list() == [8.4, 6.1, 7.25]
+
     def test_utf8_sig_is_accepted_and_the_bom_is_dropped(self, tmp_path):
         """Checked against Polars rather than assumed: it strips the BOM."""
         csv_path = tmp_path / "bom.csv"

--- a/tests/test_data_source_opener.py
+++ b/tests/test_data_source_opener.py
@@ -29,6 +29,7 @@ from qalita_core.data_source_opener import (
     _build_parquet_path,
     _infer_format_from_path,
     _materialize_remote_to_parquet,
+    _csv_read_options,
     DEFAULT_PORTS,
 )
 
@@ -774,3 +775,211 @@ class TestSqlStreaming:
         )
         assert len(paths) == 1
         assert pl.scan_parquet(paths).select(pl.len()).collect().item() == 0
+
+
+class TestCsvSourceOptions:
+    """CSV reader options declared on the source reach the reader.
+
+    Regression for qalita/core#47: the factory kept only ``config['path']``, so
+    a source declaring ``;`` was read as if it were comma-separated.
+    """
+
+    # The European shape: semicolon-separated, comma as the decimal mark. Read
+    # with the defaults, the header is one field and every data row is three,
+    # which is the ComputeError seen on the on-prem deployment.
+    EUROPEAN = (
+        "bilan_id;patient_id;date_bilan;hba1c_pct;glucose_aj_gl\n"
+        "BIO0001_01;PAT0001;2023-01-07;8,4;3,33\n"
+        "BIO0002_01;PAT0002;2023-02-11;6,1;1,05\n"
+        "BIO0003_01;PAT0003;2023-03-02;7,25;2,4\n"
+    )
+
+    def _european(self, tmp_path):
+        csv_path = tmp_path / "bilans.csv"
+        csv_path.write_text(self.EUROPEAN, encoding="utf-8")
+        return csv_path
+
+    @staticmethod
+    def _collect(source, tmp_path):
+        paths = source.get_data(
+            pack_config={"parquet_output_dir": str(tmp_path / "out")}
+        )
+        return pl.scan_parquet(paths).collect()
+
+    def test_delimiter_and_decimal_separator_are_both_applied(self, tmp_path):
+        csv_path = self._european(tmp_path)
+        source = FileSource(
+            str(csv_path),
+            config={
+                "path": str(csv_path),
+                "delimiter": ";",
+                "decimal_separator": ",",
+            },
+        )
+
+        frame = self._collect(source, tmp_path)
+
+        assert frame.columns == [
+            "bilan_id",
+            "patient_id",
+            "date_bilan",
+            "hba1c_pct",
+            "glucose_aj_gl",
+        ]
+        assert frame.height == 3
+        # The schema is the assertion that matters: the separator alone gives
+        # five columns too, but leaves these two as String and every numeric
+        # metric computed from them wrong.
+        assert frame.schema["hba1c_pct"] == pl.Float64
+        assert frame.schema["glucose_aj_gl"] == pl.Float64
+        assert frame["hba1c_pct"].to_list() == [8.4, 6.1, 7.25]
+
+    def test_delimiter_alone_leaves_the_numbers_as_strings(self, tmp_path):
+        """Pins the half-fix that turns a crash into silent wrong metrics."""
+        csv_path = self._european(tmp_path)
+        source = FileSource(
+            str(csv_path), config={"path": str(csv_path), "delimiter": ";"}
+        )
+
+        frame = self._collect(source, tmp_path)
+
+        assert frame.width == 5
+        assert frame.schema["hba1c_pct"] == pl.String
+
+    def test_semicolon_file_without_options_still_fails(self, tmp_path):
+        """No ``truncate_ragged_lines`` on this path, on purpose.
+
+        Tolerating ragged lines would return the file as one wide string
+        column instead of failing — a green job describing nothing.
+        """
+        csv_path = self._european(tmp_path)
+        source = FileSource(str(csv_path))
+
+        with pytest.raises(pl.exceptions.ComputeError):
+            self._collect(source, tmp_path)
+
+    def test_has_header_false_keeps_the_first_line_as_data(self, tmp_path):
+        csv_path = tmp_path / "headless.csv"
+        csv_path.write_text("1;alpha\n2;beta\n", encoding="utf-8")
+        source = FileSource(
+            str(csv_path),
+            config={
+                "path": str(csv_path),
+                "delimiter": ";",
+                "has_header": False,
+            },
+        )
+
+        frame = self._collect(source, tmp_path)
+
+        assert frame.height == 2
+        assert frame.columns == ["column_1", "column_2"]
+        assert frame["column_1"].to_list() == [1, 2]
+
+    def test_utf8_sig_is_accepted_and_the_bom_is_dropped(self, tmp_path):
+        """Checked against Polars rather than assumed: it strips the BOM."""
+        csv_path = tmp_path / "bom.csv"
+        csv_path.write_bytes("id;prix\n1;2,5\n".encode("utf-8-sig"))
+        source = FileSource(
+            str(csv_path),
+            config={
+                "path": str(csv_path),
+                "delimiter": ";",
+                "encoding": "utf-8-sig",
+                "decimal_separator": ",",
+            },
+        )
+
+        frame = self._collect(source, tmp_path)
+
+        assert frame.columns == ["id", "prix"]
+        assert frame["prix"].to_list() == [2.5]
+
+    def test_defaults_are_unchanged_when_nothing_is_declared(self, tmp_path):
+        csv_path = tmp_path / "plain.csv"
+        csv_path.write_text("id,value\n1,10.5\n2,20.25\n", encoding="utf-8")
+
+        bare = self._collect(FileSource(str(csv_path)), tmp_path / "bare")
+        configured = self._collect(
+            FileSource(str(csv_path), config={"path": str(csv_path)}),
+            tmp_path / "configured",
+        )
+
+        assert bare.columns == ["id", "value"]
+        assert bare.schema["value"] == pl.Float64
+        assert configured.equals(bare)
+
+    def test_factory_hands_the_config_to_the_file_source(self, tmp_path):
+        csv_path = self._european(tmp_path)
+        source = get_data_source(
+            {
+                "type": "csv",
+                "config": {
+                    "path": str(csv_path),
+                    "delimiter": ";",
+                    "decimal_separator": ",",
+                },
+            }
+        )
+
+        assert isinstance(source, FileSource)
+        assert self._collect(source, tmp_path).schema["hba1c_pct"] == (
+            pl.Float64
+        )
+
+
+class TestCsvReadOptions:
+    """Translation of a source config into reader options."""
+
+    def test_empty_config_asks_for_nothing(self):
+        assert _csv_read_options(None) == {}
+        assert _csv_read_options({}) == {}
+        assert _csv_read_options({"path": "/tmp/x.csv"}) == {}
+
+    def test_tabulation_is_accepted_as_the_two_character_escape(self):
+        # The form field is free text, so this is how a tab is usually typed.
+        assert _csv_read_options({"delimiter": "\\t"}) == {"separator": "\t"}
+        assert _csv_read_options({"delimiter": "\t"}) == {"separator": "\t"}
+
+    def test_multi_character_delimiter_names_the_value(self):
+        with pytest.raises(ValueError, match=r"'\|\|'"):
+            _csv_read_options({"delimiter": "||"})
+
+    def test_empty_delimiter_falls_back_to_the_default(self):
+        assert _csv_read_options({"delimiter": ""}) == {}
+
+    def test_utf8_family_maps_to_the_single_polars_name(self):
+        for name in ("utf-8", "UTF8", "utf_8", "utf-8-sig", "ascii"):
+            assert _csv_read_options({"encoding": name}) == {
+                "encoding": "utf8"
+            }
+
+    def test_unsupported_encoding_says_what_to_do(self):
+        with pytest.raises(ValueError) as excinfo:
+            _csv_read_options({"encoding": "latin-1"})
+        message = str(excinfo.value)
+        assert "latin-1" in message
+        assert "UTF-8" in message
+
+    def test_decimal_separator_maps_to_decimal_comma(self):
+        assert _csv_read_options({"decimal_separator": ","}) == {
+            "decimal_comma": True
+        }
+        assert _csv_read_options({"decimal_separator": "."}) == {
+            "decimal_comma": False
+        }
+
+    def test_decimal_comma_boolean_is_accepted_too(self):
+        assert _csv_read_options({"decimal_comma": True}) == {
+            "decimal_comma": True
+        }
+
+    def test_unknown_decimal_separator_names_the_value(self):
+        with pytest.raises(ValueError, match=r"';'"):
+            _csv_read_options({"decimal_separator": ";"})
+
+    def test_has_header_is_only_sent_when_declared(self):
+        assert _csv_read_options({"has_header": False}) == {
+            "has_header": False
+        }
+        assert _csv_read_options({"has_header": True}) == {"has_header": True}


### PR DESCRIPTION
Closes #47

## Cause racine

`get_data_source` construisait `FileSource(config.get("path"))` : le chemin
survivait, tout le reste de la config source était jeté à la fabrique. Le
lecteur en aval n'avait donc jamais rien à honorer — et `pio.scan_csv`
n'exposait de toute façon ni `separator`, ni `has_header`, ni `decimal_comma`.

Sur un CSV `;`, l'en-tête est parsé comme un champ unique, puis la première
ligne de données contenant une virgule fait lever
`ComputeError: found more fields than defined in 'Schema'`. Reproduit sur la
branche de base avant correctif :

```
FileSource(config=...) -> TypeError: unexpected keyword argument 'config'
get_data_source(...)   -> ComputeError: found more fields than defined in 'Schema'
```

## Ce qui change

- `qalita_core/polars_io.py`
  - `scan_csv` expose `separator`, `has_header`, `decimal_comma`.
  - La normalisation d'encodage passe de deux noms (`utf-8`, `utf_8`) à toute
    la famille utf-8 via la constante `UTF8_ENCODINGS`
    (`utf-8`, `utf8`, `utf-8-sig`, `utf8-sig`, `ascii`) → `utf8`, le seul nom
    que Polars accepte. Avant, déclarer `utf-8-sig` faisait rejeter le nom par
    Polars.
- `qalita_core/data_source_opener.py`
  - `_csv_read_options(config)` traduit la config source en kwargs de lecture.
    Chaque valeur inutilisable lève une `ValueError` qui **nomme la valeur
    reçue** plutôt que de retomber sur le défaut :
    - délimiteur de longueur != 1 après normalisation (la séquence littérale
      `\t` est acceptée, le champ étant du texte libre côté formulaire) ;
    - encodage hors famille utf-8 → message disant de convertir le fichier en
      UTF-8. Cohérent avec `cli/qalita/internal/data_preview.py:176`. Ce n'est
      pas une régression : aujourd'hui l'option est ignorée, donc un fichier
      latin-1 lève déjà un `ComputeError: invalid utf-8 sequence` opaque —
      vérifié empiriquement ;
    - `decimal_separator` hors `.` / `,`. Un booléen `decimal_comma` est
      accepté en secours s'il est présent dans la config.
  - `FileSource.__init__(file_path, config=None)` : **kwarg optionnel**, les
    appels positionnels `FileSource(str(path))` existants (une dizaine dans
    `tests/test_drivers_extended.py`) sont inchangés.
  - `FileSource._load_file` applique les options sur le chemin CSV.
  - `get_data_source` passe la config à `FileSource`.
  - `_materialize_remote_to_parquet` applique les mêmes options au CSV
    distant (S3 / GCS / Azure Blob / HDFS) : même lecteur, mêmes clés de
    config, même défaut.

### Les deux pièges

- **Pas de `truncate_ragged_lines`.** C'est ce qui masque le problème côté
  preview du CLI : un CSV mal séparé revient en une colonne unique au lieu
  d'échouer. Le chemin pack reste strict, et un test le verrouille.
- **Séparateur et convention décimale ensemble.** Corriger le seul séparateur
  fait passer le job au vert avec des colonnes numériques typées `String` et
  des métriques fausses, ce qui est pire que le crash. Un test pin ce
  demi-correctif pour qu'il ne puisse pas être livré par accident.

## Ce qui est testé

17 tests ajoutés dans `tests/test_data_source_opener.py`
(`TestCsvSourceOptions`, `TestCsvReadOptions`) :

- CSV `;` + virgule décimale → 5 colonnes, bons noms, `hba1c_pct` et
  `glucose_aj_gl` en `Float64`, valeurs `[8.4, 6.1, 7.25]`. L'assertion porte
  sur le **schéma obtenu**, pas sur l'absence d'exception ;
- séparateur seul → 5 colonnes mais `String` (le demi-correctif, verrouillé) ;
- CSV `;` sans aucune option → lève toujours `ComputeError` (garde
  anti-`truncate_ragged_lines`) ;
- `has_header: false` → première ligne conservée en donnée, colonnes
  `column_1` / `column_2` ;
- `utf-8-sig` : **vérifié empiriquement**, Polars retire le BOM tout seul, il
  ne fuit pas dans le nom de la première colonne ;
- encodage `latin-1` → `ValueError` nommant l'encodage et disant quoi faire ;
- délimiteur `||` et `decimal_separator: ';'` → `ValueError` nommant la valeur ;
- `\t` (deux caractères) et une vraie tabulation → même séparateur ;
- non-régression : sans aucune option, le résultat est identique à celui de
  `FileSource(path)` d'aujourd'hui (`configured.equals(bare)`).

Suite complète : `uv run pytest tests/ -v` → **618 passed, 2 skipped,
1 xpassed** (les 2 skips = MySQLdb/pymongo absents, le xpass =
`test_sink_returns_the_files_it_wrote`, tous préexistants et sans rapport).
`uv run black qalita_core/ tests/ --check` → clean.
`tests/test_streaming_memory.py` est passé, sans relance.

## Hors périmètre

- La clé `decimal_separator` doit être ajoutée à `SourceConfig` côté
  plateforme — **qalita/platform#211**. Sans ça, elle est supprimée avant
  d'atteindre le worker et le code ci-dessus ne la verra jamais. Le
  `delimiter`, l'`encoding` et le `has_header` transitent déjà.
- Pendant côté worker (preview Studio, actions agent) : **qalita/cli#143**.
  La convention de clés et le mapping d'encodage sont volontairement
  identiques des deux côtés.
- Propagation aux packs publiés (re-lock, bump, re-push) : **qalita/packs#81**.
  Une release `qalita-core` ne suffit pas.
- Les options Excel (`sheet`, `header_row`) sont stockées sur la source et
  restent ignorées par `_load_file` : même famille de défaut, autre ticket.
- Le `skiprows` continue de venir de `pack_config`, pas de la config source :
  inchangé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011RsNFjNowhkHCi1vJij8ap
